### PR TITLE
docs: add root redirect template for sudoprivacy.github.io

### DIFF
--- a/docs/root-redirect.html
+++ b/docs/root-redirect.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SudoClaw</title>
+  <!-- 立即重定向到 landing-page -->
+  <meta http-equiv="refresh" content="0; url=/landing-page/" />
+  <link rel="canonical" href="https://sudoprivacy.github.io/landing-page/" />
+  <script>
+    // 兼容性 JS 重定向（作为 meta refresh 的备选）
+    window.location.replace('/landing-page/');
+  </script>
+</head>
+<body>
+  <p>正在跳转... 如未自动跳转，请 <a href="/landing-page/">点击这里</a>。</p>
+</body>
+</html>


### PR DESCRIPTION
Closes #29

添加 `docs/root-redirect.html`，供手动部署到 `sudoprivacy/sudoprivacy.github.io` 仓库使用，实现 `https://sudoprivacy.github.io` → `https://sudoprivacy.github.io/landing-page/` 的跳转。