### PR TITLE
fix: 公司注册地由上海改为北京

### DIFF
--- a/index.html
+++ b/index.html
@@ -2367,7 +2367,7 @@
 
         <!-- 左：版权 -->
         <p class="text-xs text-white/40 order-2 md:order-1">
-          © 2024-2026 数牍科技（上海）有限公司 &nbsp;·&nbsp; sudoprivacy.com
+          © 2024-2026 数牍科技（北京）有限公司 &nbsp;·&nbsp; sudoprivacy.com
         </p>
 
         <!-- 中：备案信息 -->

--- a/privacy.html
+++ b/privacy.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
   <!-- SEO meta tags (customize per page) -->
-  <meta name="description" content="SudoClaw 隐私政策 — 数牍科技（上海）有限公司" />
+  <meta name="description" content="SudoClaw 隐私政策 — 数牍科技（北京）有限公司" />
   <meta name="keywords" content="AI 劳动力, 企业 AI, SudoClaw, Nexus OS, SudoRouter, 智能体" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="SudoClaw" />
@@ -242,7 +242,7 @@
 
   <!-- 标题 -->
   <h1 class="text-3xl md:text-4xl font-black text-dark mb-3">SudoClaw 隐私政策</h1>
-  <p class="text-sm text-gray-500 mb-12">最后更新：2026 年 3 月 &nbsp;·&nbsp; 数牍科技（上海）有限公司</p>
+  <p class="text-sm text-gray-500 mb-12">最后更新：2026 年 3 月 &nbsp;·&nbsp; 数牍科技（北京）有限公司</p>
 
   <div class="prose-legal">
 
@@ -250,7 +250,7 @@
     <section class="mb-10">
       <h2 class="text-xl font-bold text-dark mb-4 pb-2 border-b border-gray-200">1. 数据收集范围</h2>
       <p class="text-gray-700 leading-relaxed mb-4">
-        数牍科技（上海）有限公司（"我们"）在提供 SudoClaw 服务过程中可能收集以下类型的信息：
+        数牍科技（北京）有限公司（"我们"）在提供 SudoClaw 服务过程中可能收集以下类型的信息：
       </p>
       <h3 class="text-base font-bold text-dark mb-2">1.1 账户信息</h3>
       <ul class="list-disc list-inside space-y-2 text-gray-700 mb-4">
@@ -329,7 +329,7 @@
         如您对本隐私政策有任何疑问，或需要行使数据主体权利（包括数据查阅、更正、删除等），请通过以下方式联系我们：
       </p>
       <ul class="space-y-2 text-gray-700 mb-6">
-        <li>公司名称：数牍科技（上海）有限公司</li>
+        <li>公司名称：数牍科技（北京）有限公司</li>
         <li>个人信息保护负责人：<span class="text-gray-500">[ 待补充 ]</span></li>
         <li>隐私事务邮箱：<a href="mailto:privacy@sudoprivacy.com" class="text-teal hover:text-teal-hover">privacy@sudoprivacy.com</a></li>
         <li>通讯地址：北京市海淀区成府路28号优盛大厦A座18层</li>
@@ -414,7 +414,7 @@
 
         <!-- 左：版权 -->
         <p class="text-xs text-white/40 order-2 md:order-1">
-          © 2024-2026 数牍科技（上海）有限公司 &nbsp;·&nbsp; sudoprivacy.com
+          © 2024-2026 数牍科技（北京）有限公司 &nbsp;·&nbsp; sudoprivacy.com
         </p>
 
         <!-- 中：备案信息 -->

--- a/src/sections/footer-cta.html
+++ b/src/sections/footer-cta.html
@@ -188,7 +188,7 @@
 
         <!-- 左：版权 -->
         <p class="text-xs text-white/40 order-2 md:order-1">
-          © 2024-2026 数牍科技（上海）有限公司 &nbsp;·&nbsp; sudoprivacy.com
+          © 2024-2026 数牍科技（北京）有限公司 &nbsp;·&nbsp; sudoprivacy.com
         </p>
 
         <!-- 中：备案信息 -->

--- a/terms.html
+++ b/terms.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
   <!-- SEO meta tags (customize per page) -->
-  <meta name="description" content="SudoClaw 服务条款 — 数牍科技（上海）有限公司" />
+  <meta name="description" content="SudoClaw 服务条款 — 数牍科技（北京）有限公司" />
   <meta name="keywords" content="AI 劳动力, 企业 AI, SudoClaw, Nexus OS, SudoRouter, 智能体" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="SudoClaw" />
@@ -242,7 +242,7 @@
 
   <!-- 标题 -->
   <h1 class="text-3xl md:text-4xl font-black text-dark mb-3">SudoClaw 服务条款</h1>
-  <p class="text-sm text-gray-500 mb-12">最后更新：2026 年 3 月 &nbsp;·&nbsp; 数牍科技（上海）有限公司</p>
+  <p class="text-sm text-gray-500 mb-12">最后更新：2026 年 3 月 &nbsp;·&nbsp; 数牍科技（北京）有限公司</p>
 
   <div class="prose-legal">
 
@@ -250,7 +250,7 @@
     <section class="mb-10">
       <h2 class="text-xl font-bold text-dark mb-4 pb-2 border-b border-gray-200">1. 服务说明</h2>
       <p class="text-gray-700 leading-relaxed mb-4">
-        本服务条款（"本条款"）由数牍科技（上海）有限公司（"公司"、"我们"）与您（"用户"、"企业客户"）就使用 SudoClaw 企业级 AI 工作客户端及相关服务（统称"服务"）订立。
+        本服务条款（"本条款"）由数牍科技（北京）有限公司（"公司"、"我们"）与您（"用户"、"企业客户"）就使用 SudoClaw 企业级 AI 工作客户端及相关服务（统称"服务"）订立。
       </p>
       <p class="text-gray-700 leading-relaxed mb-4">
         SudoClaw 是一款面向企业的硅基劳动力平台，提供 AI 智能体编排、多模型路由、私有化部署等核心能力，帮助企业将 AI 从聊天工具升级为可闭环执行的数字劳动力。
@@ -336,7 +336,7 @@
         本条款受中华人民共和国法律管辖并依其解释，不考虑法律冲突原则。
       </p>
       <p class="text-gray-700 leading-relaxed mb-4">
-        因本条款或本服务引起的任何争议，双方应首先通过友好协商解决。协商不成的，任何一方均可将争议提交上海市有管辖权的人民法院诉讼解决。
+        因本条款或本服务引起的任何争议，双方应首先通过友好协商解决。协商不成的，任何一方均可将争议提交北京市有管辖权的人民法院诉讼解决。
       </p>
       <p class="text-gray-700 leading-relaxed">
         如本条款的任何条款被认定为无效或不可执行，该条款将被修改以尽量反映双方原始意图，其余条款仍继续有效。
@@ -350,7 +350,7 @@
         如您对本服务条款有任何疑问，请通过以下方式联系我们：
       </p>
       <ul class="space-y-2 text-gray-700">
-        <li>公司名称：数牍科技（上海）有限公司</li>
+        <li>公司名称：数牍科技（北京）有限公司</li>
         <li>电子邮件：<a href="mailto:legal@sudoprivacy.com" class="text-teal hover:text-teal-hover">legal@sudoprivacy.com</a></li>
         <li>通讯地址：北京市海淀区成府路28号优盛大厦A座18层</li>
       </ul>
@@ -431,7 +431,7 @@
 
         <!-- 左：版权 -->
         <p class="text-xs text-white/40 order-2 md:order-1">
-          © 2024-2026 数牍科技（上海）有限公司 &nbsp;·&nbsp; sudoprivacy.com
+          © 2024-2026 数牍科技（北京）有限公司 &nbsp;·&nbsp; sudoprivacy.com
         </p>
 
         <!-- 中：备案信息 -->


### PR DESCRIPTION
将所有页面中“数牍科技（上海）有限公司”更正为“数牍科技（北京）有限公司”

Fixes #31

Generated with [Claude Code](https://claude.ai/code)