### PR TITLE
feat: replace hero image with AI workforce concept art

### DIFF
--- a/index.html
+++ b/index.html
@@ -387,10 +387,10 @@
             aria-hidden="true"
           ></div>
           <!-- Mockup image / placeholder -->
-          <div class="relative w-full rounded-2xl overflow-hidden border border-white/20 bg-white/10 aspect-video flex items-center justify-center">
+          <div class="relative w-full rounded-2xl overflow-hidden border border-white/20 bg-white/10 aspect-[784/1168] flex items-center justify-center">
             <img
-              src="assets/images/hero-mockup.jpg"
-              alt="SudoClaw Copilot 产品界面截图"
+              src="assets/images/hero-mockup-v2.jpg"
+              alt="SudoClaw AI 劳动力概念图：指挥 Copilot 与 Workers 的 AI 工作流"
               class="w-full h-full object-cover"
               onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';"
             />


### PR DESCRIPTION
Replaces `hero-mockup.jpg` with the new `hero-mockup-v2.jpg` in the homepage hero section. Adjusts container aspect ratio from 16:9 to match the portrait image dimensions (784x1168).

Closes #34

Generated with [Claude Code](https://claude.ai/code)