### PR TITLE
fix: align SudoClaw card image height to match Nexus OS and SudoRouter

### DIFF
--- a/index.html
+++ b/index.html
@@ -896,11 +896,11 @@
       <div class="fade-up bg-white rounded-2xl overflow-hidden shadow-sm hover:shadow-md hover:-translate-y-1 transition-all flex flex-col"
            style="transition-delay: 0s;">
         <!-- Product Diagram -->
-        <div class="cursor-zoom-in" data-lightbox>
+        <div class="cursor-zoom-in overflow-hidden" data-lightbox>
           <img
             src="assets/images/product-sudoclaw-diagram.jpg"
             alt="SudoClaw Copilot+Worker 工作流图"
-            class="w-full object-cover hover:scale-[1.02] transition-transform duration-300"
+            class="w-full h-44 object-cover hover:scale-[1.02] transition-transform duration-300"
           />
         </div>
 


### PR DESCRIPTION
Fix visual misalignment in the product matrix section by adding `h-44` to the SudoClaw card image, matching the Nexus OS and SudoRouter cards.

Related to PR #32.

Generated with [Claude Code](https://claude.ai/code)