### PR TITLE
Replace HTML comparison diagram with architecture-comparison.jpg

### DIFF
--- a/index.html
+++ b/index.html
@@ -686,37 +686,10 @@
       />
     </div>
 
-    <!-- 对比流程 -->
-    <div class="bg-white rounded-2xl p-8 shadow-sm mb-8 fade-up" style="transition-delay: 0.45s;">
-      <h3 class="text-lg font-bold text-dark mb-6 text-center">传统 AI 工具 vs SudoClaw</h3>
-
-      <!-- 传统 AI：灰色 -->
-      <div class="mb-5">
-        <div class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">传统 AI 工具</div>
-        <div class="flex flex-wrap items-center gap-2">
-          <span class="rounded-full px-4 py-2 text-sm font-medium bg-gray-100 text-gray-500">人提问</span>
-          <span class="text-gray-300 font-bold text-lg">→</span>
-          <span class="rounded-full px-4 py-2 text-sm font-medium bg-gray-100 text-gray-500">AI 回答</span>
-          <span class="text-gray-300 font-bold text-lg">→</span>
-          <span class="rounded-full px-4 py-2 text-sm font-medium bg-gray-100 text-gray-500">人再操作</span>
-        </div>
-      </div>
-
-      <div class="border-t border-border my-5"></div>
-
-      <!-- SudoClaw：accent 色 -->
-      <div>
-        <div class="text-xs font-semibold uppercase tracking-wider mb-2" style="color: var(--accent);">SudoClaw</div>
-        <div class="flex flex-wrap items-center gap-2">
-          <span class="rounded-full px-4 py-2 text-sm font-semibold text-dark" style="background-color: var(--accent-light);">人下达意图</span>
-          <span class="font-bold text-lg" style="color: var(--accent);">→</span>
-          <span class="rounded-full px-4 py-2 text-sm font-semibold text-dark" style="background-color: var(--accent-light);">Copilot 理解拆解</span>
-          <span class="font-bold text-lg" style="color: var(--accent);">→</span>
-          <span class="rounded-full px-4 py-2 text-sm font-semibold text-dark" style="background-color: var(--accent-light);">Worker 并行执行</span>
-          <span class="font-bold text-lg" style="color: var(--accent);">→</span>
-          <span class="rounded-full px-4 py-2 text-sm font-semibold text-white" style="background-color: var(--accent);">结果直接交付</span>
-        </div>
-      </div>
+    <div class="mb-8 fade-up" style="transition-delay: 0.45s;">
+      <img src="assets/images/architecture-comparison.jpg"
+           alt="传统 AI 工具 vs SudoClaw"
+           class="w-full rounded-2xl shadow-sm" />
     </div>
 
     <!-- 真实案例引用 -->


### PR DESCRIPTION
Replace the HTML-rendered comparison block with the `assets/images/architecture-comparison.jpg` image in the architecture section of index.html.

Closes #37

Generated with [Claude Code](https://claude.ai/code)