### PR TITLE
feat: add standalone /github-release page for SudoWork releases

### DIFF
--- a/github-release.html
+++ b/github-release.html
@@ -1,0 +1,897 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <!-- ============================================================
+       SudoWork GitHub Releases (独立页面)
+       通过 GitHub API 获取 sudoprivacy/sudowork 的所有版本，
+       按发布时间（published_at）倒序排列，区分正式版与预发布，
+       并为每个资源提供多个国内可用的加速下载镜像。
+       ============================================================ -->
+
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex,nofollow" />
+
+  <meta name="description" content="SudoWork 版本下载 — 通过 GitHub API 按发布时间排序，支持国内加速镜像下载" />
+  <link rel="icon" href="assets/favicon.ico" />
+  <meta name="theme-color" content="#FAF9F0" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="preconnect" href="https://api.github.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;500;700;900&family=JetBrains+Mono:wght@400;500;700&display=swap"
+    rel="stylesheet"
+  />
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            page: '#FAF9F0',
+            dark: '#1a1a1a',
+            'dark-footer': '#111111',
+            accent: '#F59E0B',
+            'accent-hover': '#D97706',
+            'accent-light': '#FEF3C7',
+            teal: '#0D9488',
+            'teal-hover': '#0F766E',
+            border: '#E5E7EB',
+          },
+          fontFamily: {
+            heading: ['"Noto Sans SC"', '"PingFang SC"', '"Microsoft YaHei"', 'sans-serif'],
+            body: ['"Noto Sans SC"', '"PingFang SC"', '"Microsoft YaHei"', 'sans-serif'],
+            mono: ['"JetBrains Mono"', '"Fira Code"', 'monospace'],
+          },
+          maxWidth: {
+            content: '1100px',
+          },
+        },
+      },
+    }
+  </script>
+
+  <!-- Markdown 渲染（jsDelivr 国内可用） -->
+  <script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
+
+  <style>
+    :root {
+      --bg-page: #faf9f0;
+      --bg-card: #ffffff;
+      --bg-dark: #1a1a1a;
+      --bg-footer: #111111;
+      --text-primary: #1a1a1a;
+      --text-secondary: #6b7280;
+      --accent: #f59e0b;
+      --accent-hover: #d97706;
+      --accent-light: #fef3c7;
+      --teal: #0d9488;
+      --teal-hover: #0f766e;
+      --border: #e5e7eb;
+      --font-heading: "Noto Sans SC", "PingFang SC", "Microsoft YaHei", sans-serif;
+      --font-body: "Noto Sans SC", "PingFang SC", "Microsoft YaHei", sans-serif;
+      --font-mono: "JetBrains Mono", "Fira Code", monospace;
+      --max-width: 1100px;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+
+    html {
+      scroll-behavior: smooth;
+      font-size: 16px;
+      -webkit-text-size-adjust: 100%;
+    }
+
+    body {
+      margin: 0;
+      background-color: var(--bg-page);
+      color: var(--text-primary);
+      font-family: var(--font-body);
+      font-weight: 400;
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    h1, h2, h3, h4, h5, h6 {
+      font-family: var(--font-heading);
+      font-weight: 700;
+      line-height: 1.25;
+      color: var(--text-primary);
+      margin-top: 0;
+      margin-bottom: 0.5em;
+    }
+    h1 { font-weight: 900; }
+
+    a {
+      color: var(--teal);
+      text-decoration: none;
+      transition: color 0.2s ease;
+    }
+    a:hover { color: var(--teal-hover); }
+
+    /* 骨架屏 */
+    .skeleton {
+      background: linear-gradient(90deg, #eef0f2 25%, #f5f6f8 50%, #eef0f2 75%);
+      background-size: 200% 100%;
+      animation: shimmer 1.4s infinite;
+      border-radius: 6px;
+    }
+    @keyframes shimmer {
+      0%   { background-position: 200% 0; }
+      100% { background-position: -200% 0; }
+    }
+
+    /* Spinner */
+    .spinner {
+      width: 28px;
+      height: 28px;
+      border: 3px solid rgba(13, 148, 136, 0.2);
+      border-top-color: var(--teal);
+      border-radius: 50%;
+      animation: spin 0.9s linear infinite;
+      display: inline-block;
+    }
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+
+    /* Release 卡片 body (markdown prose) */
+    .release-body {
+      font-size: 0.95rem;
+      color: #374151;
+    }
+    .release-body h1,
+    .release-body h2,
+    .release-body h3,
+    .release-body h4 {
+      margin-top: 1.2em;
+      margin-bottom: 0.5em;
+      color: var(--text-primary);
+    }
+    .release-body h1 { font-size: 1.3rem; font-weight: 700; }
+    .release-body h2 { font-size: 1.15rem; font-weight: 700; }
+    .release-body h3 { font-size: 1rem; font-weight: 700; }
+    .release-body h4 { font-size: 0.95rem; font-weight: 700; }
+    .release-body p {
+      margin: 0 0 0.75em 0;
+      line-height: 1.7;
+    }
+    .release-body ul,
+    .release-body ol {
+      padding-left: 1.5rem;
+      margin-bottom: 0.75em;
+    }
+    .release-body li { margin-bottom: 0.25em; }
+    .release-body a {
+      color: var(--teal);
+      text-decoration: underline;
+      text-underline-offset: 2px;
+      word-break: break-all;
+    }
+    .release-body code {
+      font-family: var(--font-mono);
+      background: #f3f4f6;
+      padding: 0.1em 0.4em;
+      border-radius: 4px;
+      font-size: 0.85em;
+    }
+    .release-body pre {
+      background: #1a1a1a;
+      color: #e5e7eb;
+      padding: 0.9rem 1rem;
+      border-radius: 8px;
+      overflow-x: auto;
+      margin: 0 0 0.9em 0;
+      font-family: var(--font-mono);
+      font-size: 0.82rem;
+      line-height: 1.55;
+    }
+    .release-body pre code {
+      background: none;
+      padding: 0;
+      font-size: inherit;
+      color: inherit;
+    }
+    .release-body blockquote {
+      border-left: 4px solid var(--accent);
+      padding: 0.2em 0 0.2em 1rem;
+      margin: 0 0 0.75em 0;
+      color: #6b7280;
+      font-style: italic;
+    }
+    .release-body table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-bottom: 0.9em;
+      font-size: 0.9rem;
+    }
+    .release-body th,
+    .release-body td {
+      border: 1px solid var(--border);
+      padding: 0.45rem 0.7rem;
+      text-align: left;
+    }
+    .release-body th {
+      background: #f9fafb;
+      font-weight: 700;
+    }
+    .release-body hr {
+      border: none;
+      border-top: 1px solid var(--border);
+      margin: 1rem 0;
+    }
+    .release-body img {
+      max-width: 100%;
+      border-radius: 6px;
+    }
+
+    /* 折叠 body */
+    .body-collapsed {
+      max-height: 360px;
+      overflow: hidden;
+      position: relative;
+    }
+    .body-collapsed::after {
+      content: "";
+      position: absolute;
+      inset: auto 0 0 0;
+      height: 80px;
+      background: linear-gradient(to bottom, rgba(255,255,255,0), #ffffff);
+      pointer-events: none;
+    }
+
+    .filter-btn.active {
+      background: var(--dark, #1a1a1a);
+      color: #ffffff;
+      border-color: var(--dark, #1a1a1a);
+    }
+
+    .asset-row:hover {
+      background: #fafbfc;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      html { scroll-behavior: auto; }
+      .skeleton, .spinner { animation: none; }
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+  </style>
+
+  <title>SudoWork Releases — 版本下载</title>
+</head>
+<body class="bg-page">
+
+<!-- 顶部（独立页面，不链接到站内其他页） -->
+<header class="bg-dark text-white">
+  <div class="max-w-content mx-auto px-6 md:px-8 py-10 md:py-14">
+    <div class="flex items-center gap-3 mb-4">
+      <img
+        src="assets/logo/app.png"
+        alt="SudoClaw Logo"
+        class="h-10 w-10 rounded-lg object-contain bg-white/5 p-1"
+        onerror="this.style.display='none'"
+      />
+      <span class="font-heading font-black text-xl leading-none select-none">
+        <span class="text-white">Sudo</span><span class="text-accent">Work</span>
+      </span>
+    </div>
+    <h1 class="text-3xl md:text-4xl font-black">版本下载 · Releases</h1>
+    <p class="text-white/70 mt-3 text-base md:text-lg max-w-2xl">
+      通过 GitHub API 实时获取
+      <a
+        href="https://github.com/sudoprivacy/sudowork/releases"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-accent hover:text-accent-hover underline underline-offset-2"
+      >sudoprivacy/sudowork</a>
+      的所有版本，按 <code class="font-mono text-sm bg-white/10 px-1.5 py-0.5 rounded">published_at</code>
+      倒序排列，区分正式版 / 预发布，并提供国内可用的加速下载镜像。
+    </p>
+  </div>
+</header>
+
+<main class="max-w-content mx-auto px-6 md:px-8 py-8 md:py-10">
+
+  <!-- 控制栏：筛选 + 镜像 + 刷新 -->
+  <section class="mb-6 md:mb-8 flex flex-col gap-4">
+    <div class="flex flex-wrap items-center gap-3">
+      <span class="text-sm text-secondary font-medium">版本类型：</span>
+      <div class="flex flex-wrap gap-2" role="tablist" aria-label="版本类型筛选">
+        <button type="button" class="filter-btn active border border-border bg-white text-dark text-sm font-medium px-4 py-1.5 rounded-full transition" data-filter="all" role="tab" aria-selected="true">全部</button>
+        <button type="button" class="filter-btn border border-border bg-white text-dark text-sm font-medium px-4 py-1.5 rounded-full transition" data-filter="release" role="tab" aria-selected="false">正式版</button>
+        <button type="button" class="filter-btn border border-border bg-white text-dark text-sm font-medium px-4 py-1.5 rounded-full transition" data-filter="prerelease" role="tab" aria-selected="false">预发布</button>
+      </div>
+    </div>
+
+    <div class="flex flex-wrap items-center gap-3">
+      <label for="mirror-select" class="text-sm text-secondary font-medium">下载镜像：</label>
+      <select
+        id="mirror-select"
+        class="border border-border bg-white text-dark text-sm font-medium px-3 py-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal/40"
+        aria-label="选择下载镜像"
+      >
+        <option value="direct">官方直连（github.com）</option>
+        <option value="ghfast" selected>ghfast.top 加速（推荐）</option>
+        <option value="ghproxy">gh-proxy.com 加速</option>
+        <option value="ghproxyMirror">mirror.ghproxy.com 加速</option>
+        <option value="moeyy">github.moeyy.xyz 加速</option>
+      </select>
+      <button
+        id="refresh-btn"
+        type="button"
+        class="ml-auto border border-border bg-white hover:bg-gray-50 text-dark text-sm font-medium px-4 py-1.5 rounded-lg transition inline-flex items-center gap-1.5"
+        aria-label="刷新版本列表"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 3v6h-6"/></svg>
+        刷新
+      </button>
+    </div>
+
+    <p class="text-xs text-secondary leading-relaxed">
+      提示：切换镜像后，下方所有资源的"下载"按钮会同步更新。若某个镜像不可用，可随时切换。
+      GitHub API 每小时对未登录用户有 60 次请求的限制，通常访问一次本页会消耗 1 次。
+    </p>
+  </section>
+
+  <!-- 加载中 -->
+  <div id="loading" class="py-12">
+    <div class="flex items-center justify-center gap-3 text-secondary">
+      <span class="spinner"></span>
+      <span class="text-sm">正在从 GitHub 拉取版本列表…</span>
+    </div>
+    <div class="mt-8 space-y-4">
+      <div class="bg-white rounded-2xl p-6 shadow-sm">
+        <div class="skeleton h-6 w-1/3 mb-3"></div>
+        <div class="skeleton h-4 w-1/2 mb-5"></div>
+        <div class="skeleton h-4 w-full mb-2"></div>
+        <div class="skeleton h-4 w-11/12 mb-2"></div>
+        <div class="skeleton h-4 w-4/5"></div>
+      </div>
+      <div class="bg-white rounded-2xl p-6 shadow-sm">
+        <div class="skeleton h-6 w-1/4 mb-3"></div>
+        <div class="skeleton h-4 w-2/5 mb-5"></div>
+        <div class="skeleton h-4 w-full mb-2"></div>
+        <div class="skeleton h-4 w-10/12"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 错误 -->
+  <div id="error" hidden class="py-12">
+    <div class="max-w-lg mx-auto bg-white border border-red-200 rounded-2xl p-6 shadow-sm">
+      <div class="flex items-start gap-3">
+        <div class="flex-shrink-0 w-10 h-10 rounded-full bg-red-50 flex items-center justify-center text-red-500">
+          <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+        </div>
+        <div class="flex-1">
+          <h2 class="text-lg font-bold text-dark mb-1">加载失败</h2>
+          <p id="error-msg" class="text-sm text-secondary mb-4">无法从 GitHub API 获取版本信息。</p>
+          <div class="flex flex-wrap gap-2">
+            <button id="retry-btn" type="button" class="bg-accent hover:bg-accent-hover text-dark font-bold text-sm px-4 py-2 rounded-lg transition">重试</button>
+            <a href="https://github.com/sudoprivacy/sudowork/releases" target="_blank" rel="noopener noreferrer" class="border border-border hover:bg-gray-50 text-dark font-medium text-sm px-4 py-2 rounded-lg transition">前往 GitHub</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 空状态 -->
+  <div id="empty" hidden class="py-12 text-center">
+    <p class="text-secondary">暂无版本发布。</p>
+  </div>
+
+  <!-- 列表 -->
+  <div id="releases" class="space-y-6"></div>
+
+  <!-- 统计 -->
+  <div id="meta" hidden class="mt-8 pt-6 border-t border-border text-center text-xs text-secondary">
+    <span id="meta-count"></span>
+    <span class="mx-1">·</span>
+    <span>数据源 <a href="https://api.github.com/repos/sudoprivacy/sudowork/releases" target="_blank" rel="noopener noreferrer" class="underline">GitHub REST API</a></span>
+    <span class="mx-1">·</span>
+    <span id="meta-fetched"></span>
+  </div>
+</main>
+
+<footer class="mt-16 bg-[#111111] text-white/60 py-10">
+  <div class="max-w-content mx-auto px-6 md:px-8 text-center space-y-2">
+    <p class="text-xs text-white/40">
+      © 2019-2026 数牍科技（北京）有限公司 &nbsp;·&nbsp; sudoprivacy.com
+    </p>
+    <p class="text-xs text-white/30">
+      本页面仅供版本分发，不提供站点内导航。直接访问 URL 获取最新版本。
+    </p>
+  </div>
+</footer>
+
+<script>
+  'use strict';
+
+  // ── 常量 ─────────────────────────────────────────────────────
+  var OWNER = 'sudoprivacy';
+  var REPO = 'sudowork';
+  var API_URL = 'https://api.github.com/repos/' + OWNER + '/' + REPO + '/releases?per_page=100';
+
+  // 国内可用的 GitHub 加速镜像
+  // 每个函数接受原始 github.com 的下载 URL，返回加速后的 URL
+  var MIRRORS = {
+    direct: {
+      label: '官方直连',
+      transform: function (url) { return url; }
+    },
+    ghfast: {
+      label: 'ghfast.top',
+      transform: function (url) { return 'https://ghfast.top/' + url; }
+    },
+    ghproxy: {
+      label: 'gh-proxy.com',
+      transform: function (url) { return 'https://gh-proxy.com/' + url; }
+    },
+    ghproxyMirror: {
+      label: 'mirror.ghproxy.com',
+      transform: function (url) { return 'https://mirror.ghproxy.com/' + url; }
+    },
+    moeyy: {
+      label: 'github.moeyy.xyz',
+      transform: function (url) { return 'https://github.moeyy.xyz/' + url; }
+    }
+  };
+
+  // ── 状态 ─────────────────────────────────────────────────────
+  var state = {
+    releases: [],        // 原始数据（已按 published_at DESC 排序）
+    filter: 'all',       // all | release | prerelease
+    mirror: 'ghfast',    // 选中镜像
+    fetchedAt: null
+  };
+
+  // ── 工具函数 ─────────────────────────────────────────────────
+  function $(sel) { return document.querySelector(sel); }
+  function $all(sel) { return Array.prototype.slice.call(document.querySelectorAll(sel)); }
+
+  function escapeHtml(s) {
+    if (s == null) return '';
+    return String(s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function formatBytes(bytes) {
+    if (bytes == null || isNaN(bytes)) return '-';
+    if (bytes < 1024) return bytes + ' B';
+    var units = ['KB', 'MB', 'GB', 'TB'];
+    var i = -1;
+    var n = bytes;
+    do { n = n / 1024; i++; } while (n >= 1024 && i < units.length - 1);
+    return n.toFixed(n >= 10 || i === 0 ? 0 : 1) + ' ' + units[i];
+  }
+
+  function formatDate(iso) {
+    if (!iso) return '-';
+    try {
+      var d = new Date(iso);
+      var y = d.getFullYear();
+      var m = String(d.getMonth() + 1).padStart(2, '0');
+      var day = String(d.getDate()).padStart(2, '0');
+      var h = String(d.getHours()).padStart(2, '0');
+      var min = String(d.getMinutes()).padStart(2, '0');
+      return y + '-' + m + '-' + day + ' ' + h + ':' + min;
+    } catch (e) {
+      return iso;
+    }
+  }
+
+  function timeAgo(iso) {
+    if (!iso) return '';
+    var now = Date.now();
+    var then = new Date(iso).getTime();
+    if (isNaN(then)) return '';
+    var diff = Math.max(0, Math.floor((now - then) / 1000));
+    if (diff < 60) return '刚刚';
+    if (diff < 3600) return Math.floor(diff / 60) + ' 分钟前';
+    if (diff < 86400) return Math.floor(diff / 3600) + ' 小时前';
+    if (diff < 86400 * 30) return Math.floor(diff / 86400) + ' 天前';
+    if (diff < 86400 * 365) return Math.floor(diff / (86400 * 30)) + ' 个月前';
+    return Math.floor(diff / (86400 * 365)) + ' 年前';
+  }
+
+  function renderMarkdown(md) {
+    if (!md) return '<p class="text-secondary italic">（无发布说明）</p>';
+    try {
+      if (typeof marked === 'undefined') {
+        return '<pre style="white-space:pre-wrap">' + escapeHtml(md) + '</pre>';
+      }
+      marked.setOptions({
+        gfm: true,
+        breaks: true,
+        headerIds: false,
+        mangle: false
+      });
+      var html = marked.parse(md);
+      if (typeof DOMPurify !== 'undefined') {
+        html = DOMPurify.sanitize(html, {
+          ADD_ATTR: ['target', 'rel']
+        });
+      }
+      return html;
+    } catch (e) {
+      return '<pre style="white-space:pre-wrap">' + escapeHtml(md) + '</pre>';
+    }
+  }
+
+  function getMirror() {
+    return MIRRORS[state.mirror] || MIRRORS.direct;
+  }
+
+  // ── 数据加载 ─────────────────────────────────────────────────
+  function load() {
+    showLoading();
+    var url = API_URL + '&_t=' + Date.now(); // 破缓存
+
+    fetch(url, {
+      headers: { 'Accept': 'application/vnd.github+json' },
+      cache: 'no-store'
+    })
+      .then(function (res) {
+        if (!res.ok) {
+          var hint = '';
+          if (res.status === 403) hint = '（可能触发了 GitHub API 的速率限制，请稍后重试）';
+          if (res.status === 404) hint = '（仓库不存在或已私有）';
+          throw new Error('HTTP ' + res.status + ' ' + res.statusText + ' ' + hint);
+        }
+        return res.json();
+      })
+      .then(function (data) {
+        if (!Array.isArray(data)) throw new Error('返回数据格式异常');
+
+        // 过滤 draft，按 published_at DESC 排序（prerelease 也按时间参与排序）
+        var list = data
+          .filter(function (r) { return !r.draft; })
+          .slice()
+          .sort(function (a, b) {
+            var ta = a.published_at ? new Date(a.published_at).getTime() : 0;
+            var tb = b.published_at ? new Date(b.published_at).getTime() : 0;
+            if (tb !== ta) return tb - ta;
+            // 次级排序：created_at
+            var ca = a.created_at ? new Date(a.created_at).getTime() : 0;
+            var cb = b.created_at ? new Date(b.created_at).getTime() : 0;
+            return cb - ca;
+          });
+
+        state.releases = list;
+        state.fetchedAt = new Date();
+        render();
+      })
+      .catch(function (err) {
+        showError(err && err.message ? err.message : String(err));
+      });
+  }
+
+  function showLoading() {
+    $('#loading').hidden = false;
+    $('#error').hidden = true;
+    $('#empty').hidden = true;
+    $('#meta').hidden = true;
+    $('#releases').innerHTML = '';
+  }
+
+  function showError(msg) {
+    $('#loading').hidden = true;
+    $('#error').hidden = false;
+    $('#empty').hidden = true;
+    $('#meta').hidden = true;
+    $('#error-msg').textContent = msg || '未知错误';
+  }
+
+  // ── 渲染 ─────────────────────────────────────────────────────
+  function render() {
+    $('#loading').hidden = true;
+    $('#error').hidden = true;
+
+    var list = state.releases.filter(function (r) {
+      if (state.filter === 'all') return true;
+      if (state.filter === 'prerelease') return !!r.prerelease;
+      return !r.prerelease; // release
+    });
+
+    var container = $('#releases');
+    container.innerHTML = '';
+
+    if (!list.length) {
+      $('#empty').hidden = false;
+      $('#meta').hidden = true;
+      return;
+    }
+    $('#empty').hidden = true;
+
+    var mirror = getMirror();
+    var frag = document.createDocumentFragment();
+
+    list.forEach(function (r) {
+      frag.appendChild(renderReleaseCard(r, mirror));
+    });
+
+    container.appendChild(frag);
+
+    // meta
+    var total = state.releases.length;
+    var stable = state.releases.filter(function (r) { return !r.prerelease; }).length;
+    var pre = total - stable;
+    $('#meta').hidden = false;
+    $('#meta-count').textContent =
+      '共 ' + total + ' 个版本（正式版 ' + stable + '，预发布 ' + pre + '）· 当前筛选：' + list.length + ' 个';
+    $('#meta-fetched').textContent = '拉取时间 ' + formatDate(state.fetchedAt.toISOString());
+  }
+
+  function renderReleaseCard(r, mirror) {
+    var card = document.createElement('article');
+    card.className = 'bg-white rounded-2xl shadow-sm border border-border overflow-hidden';
+    card.setAttribute('data-prerelease', r.prerelease ? '1' : '0');
+
+    // Header
+    var header = document.createElement('div');
+    header.className = 'px-5 md:px-7 pt-5 md:pt-6 pb-3 border-b border-border';
+
+    var title = r.name && r.name.trim() ? r.name.trim() : r.tag_name || '(未命名)';
+    var tag = r.tag_name || '';
+    var isPre = !!r.prerelease;
+    var isLatest = !isPre && r === firstStableRelease();
+
+    var badges = '';
+    if (isPre) {
+      badges += '<span class="inline-flex items-center gap-1 bg-accent-light text-accent-hover border border-accent/30 text-xs font-bold px-2 py-0.5 rounded-full">预发布</span>';
+    } else {
+      badges += '<span class="inline-flex items-center gap-1 bg-emerald-50 text-emerald-700 border border-emerald-200 text-xs font-bold px-2 py-0.5 rounded-full">正式版</span>';
+    }
+    if (isLatest) {
+      badges += '<span class="inline-flex items-center gap-1 bg-teal/10 text-teal border border-teal/30 text-xs font-bold px-2 py-0.5 rounded-full">Latest</span>';
+    }
+
+    header.innerHTML =
+      '<div class="flex flex-wrap items-center gap-x-3 gap-y-2 mb-2">' +
+        badges +
+        (tag ? '<code class="font-mono text-xs bg-gray-100 text-dark px-2 py-0.5 rounded">' + escapeHtml(tag) + '</code>' : '') +
+      '</div>' +
+      '<h2 class="text-xl md:text-2xl font-bold text-dark break-words">' + escapeHtml(title) + '</h2>' +
+      '<div class="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-secondary">' +
+        (r.author && r.author.login ? '<span class="inline-flex items-center gap-1">' +
+            (r.author.avatar_url ? '<img src="' + escapeHtml(r.author.avatar_url) + '" alt="" class="w-4 h-4 rounded-full inline-block" onerror="this.style.display=\'none\'" />' : '') +
+            '<a href="' + escapeHtml(r.author.html_url || '#') + '" target="_blank" rel="noopener noreferrer" class="hover:text-dark">' + escapeHtml(r.author.login) + '</a>' +
+          '</span>' : '') +
+        '<span>发布于 ' + escapeHtml(formatDate(r.published_at)) + '</span>' +
+        '<span>' + escapeHtml(timeAgo(r.published_at)) + '</span>' +
+        (r.html_url ? '<a href="' + escapeHtml(r.html_url) + '" target="_blank" rel="noopener noreferrer" class="text-teal hover:text-teal-hover underline underline-offset-2">在 GitHub 查看 ↗</a>' : '') +
+      '</div>';
+
+    card.appendChild(header);
+
+    // Body (markdown)
+    var bodyWrap = document.createElement('div');
+    bodyWrap.className = 'px-5 md:px-7 pt-5';
+    var bodyHtml = renderMarkdown(r.body);
+    var bodyInner = document.createElement('div');
+    bodyInner.className = 'release-body body-collapsed';
+    bodyInner.innerHTML = bodyHtml;
+    bodyWrap.appendChild(bodyInner);
+
+    // "展开/收起" 按钮（如果内容较短则隐藏）
+    var toggleWrap = document.createElement('div');
+    toggleWrap.className = 'mt-2';
+    var toggleBtn = document.createElement('button');
+    toggleBtn.type = 'button';
+    toggleBtn.className = 'text-sm text-teal hover:text-teal-hover font-medium';
+    toggleBtn.textContent = '展开全文';
+    toggleBtn.addEventListener('click', function () {
+      var collapsed = bodyInner.classList.toggle('body-collapsed');
+      toggleBtn.textContent = collapsed ? '展开全文' : '收起';
+    });
+    toggleWrap.appendChild(toggleBtn);
+    bodyWrap.appendChild(toggleWrap);
+
+    // 延迟判断是否需要折叠
+    requestAnimationFrame(function () {
+      if (bodyInner.scrollHeight <= 360) {
+        bodyInner.classList.remove('body-collapsed');
+        toggleWrap.style.display = 'none';
+      }
+    });
+
+    card.appendChild(bodyWrap);
+
+    // Assets
+    var assets = Array.isArray(r.assets) ? r.assets.slice() : [];
+    var assetsWrap = document.createElement('div');
+    assetsWrap.className = 'px-5 md:px-7 pb-5 md:pb-6 pt-4';
+
+    var assetsHeader = document.createElement('div');
+    assetsHeader.className = 'flex items-center gap-2 mb-3';
+    assetsHeader.innerHTML =
+      '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-secondary" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>' +
+      '<h3 class="text-sm font-bold text-dark">下载资源 <span class="text-secondary font-normal">(' + assets.length + ')</span></h3>' +
+      '<span class="ml-auto text-xs text-secondary">当前镜像：' + escapeHtml(mirror.label) + '</span>';
+    assetsWrap.appendChild(assetsHeader);
+
+    if (!assets.length) {
+      var empty = document.createElement('p');
+      empty.className = 'text-sm text-secondary italic py-2';
+      empty.textContent = '本版本没有附加资源。';
+      assetsWrap.appendChild(empty);
+    } else {
+      var table = document.createElement('div');
+      table.className = 'divide-y divide-border border border-border rounded-xl overflow-hidden bg-white';
+
+      assets
+        .sort(function (a, b) { return (a.name || '').localeCompare(b.name || ''); })
+        .forEach(function (a) {
+          var rawUrl = a.browser_download_url || '';
+          var mirroredUrl = mirror.transform(rawUrl);
+          var row = document.createElement('div');
+          row.className = 'asset-row flex flex-col md:flex-row md:items-center gap-3 px-4 py-3';
+
+          row.innerHTML =
+            '<div class="flex-1 min-w-0">' +
+              '<div class="font-mono text-sm text-dark break-all">' + escapeHtml(a.name || '') + '</div>' +
+              '<div class="mt-0.5 text-xs text-secondary flex flex-wrap gap-x-3 gap-y-0.5">' +
+                '<span>' + formatBytes(a.size) + '</span>' +
+                (a.download_count != null ? '<span>下载 ' + a.download_count + ' 次</span>' : '') +
+                (a.updated_at ? '<span>更新 ' + escapeHtml(formatDate(a.updated_at)) + '</span>' : '') +
+              '</div>' +
+            '</div>' +
+            '<div class="flex flex-wrap gap-2 shrink-0">' +
+              '<a href="' + escapeHtml(mirroredUrl) + '" rel="noopener noreferrer"' +
+                ' class="bg-accent hover:bg-accent-hover text-dark font-bold text-sm px-4 py-2 rounded-lg transition inline-flex items-center gap-1.5">' +
+                '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>' +
+                '下载' +
+              '</a>' +
+              '<button type="button" data-raw="' + escapeHtml(rawUrl) + '"' +
+                ' class="copy-url-btn border border-border hover:bg-gray-50 text-dark text-sm px-3 py-2 rounded-lg transition inline-flex items-center gap-1.5" aria-label="复制原始下载链接">' +
+                '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>' +
+                '<span>复制原链</span>' +
+              '</button>' +
+              '<details class="relative">' +
+                '<summary class="cursor-pointer list-none border border-border hover:bg-gray-50 text-dark text-sm px-3 py-2 rounded-lg transition inline-flex items-center gap-1.5" aria-label="其他镜像">' +
+                  '其他镜像' +
+                  '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>' +
+                '</summary>' +
+                '<div class="absolute right-0 top-full mt-1 w-56 bg-white border border-border rounded-lg shadow-lg z-10 py-1">' +
+                  Object.keys(MIRRORS).map(function (key) {
+                    var m = MIRRORS[key];
+                    var href = m.transform(rawUrl);
+                    return '<a href="' + escapeHtml(href) + '" target="_blank" rel="noopener noreferrer"' +
+                      ' class="block px-3 py-2 text-sm text-dark hover:bg-gray-50 truncate">' + escapeHtml(m.label) + '</a>';
+                  }).join('') +
+                '</div>' +
+              '</details>' +
+            '</div>';
+
+          table.appendChild(row);
+        });
+
+      // Source code (tarball / zipball)
+      var srcRow = document.createElement('div');
+      srcRow.className = 'asset-row flex flex-col md:flex-row md:items-center gap-3 px-4 py-3 bg-gray-50';
+      var zipUrl = 'https://github.com/' + OWNER + '/' + REPO + '/archive/refs/tags/' + encodeURIComponent(r.tag_name || '') + '.zip';
+      var tarUrl = 'https://github.com/' + OWNER + '/' + REPO + '/archive/refs/tags/' + encodeURIComponent(r.tag_name || '') + '.tar.gz';
+      srcRow.innerHTML =
+        '<div class="flex-1 min-w-0">' +
+          '<div class="font-mono text-sm text-dark break-all">源码 Source code</div>' +
+          '<div class="mt-0.5 text-xs text-secondary">Git tag: ' + escapeHtml(r.tag_name || '-') + '</div>' +
+        '</div>' +
+        '<div class="flex flex-wrap gap-2 shrink-0">' +
+          '<a href="' + escapeHtml(mirror.transform(zipUrl)) + '" rel="noopener noreferrer" class="border border-border hover:bg-gray-50 text-dark text-sm font-medium px-3 py-2 rounded-lg transition">zip</a>' +
+          '<a href="' + escapeHtml(mirror.transform(tarUrl)) + '" rel="noopener noreferrer" class="border border-border hover:bg-gray-50 text-dark text-sm font-medium px-3 py-2 rounded-lg transition">tar.gz</a>' +
+        '</div>';
+      table.appendChild(srcRow);
+
+      assetsWrap.appendChild(table);
+    }
+
+    card.appendChild(assetsWrap);
+
+    // 绑定复制按钮
+    Array.prototype.slice.call(card.querySelectorAll('.copy-url-btn')).forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var url = btn.getAttribute('data-raw') || '';
+        if (!url) return;
+        var ok = false;
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(url).then(
+            function () { flashBtn(btn, '已复制'); },
+            function () { fallbackCopy(url, btn); }
+          );
+        } else {
+          fallbackCopy(url, btn);
+        }
+      });
+    });
+
+    return card;
+  }
+
+  function fallbackCopy(text, btn) {
+    try {
+      var ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+      flashBtn(btn, '已复制');
+    } catch (e) {
+      flashBtn(btn, '失败');
+    }
+  }
+
+  function flashBtn(btn, msg) {
+    var span = btn.querySelector('span');
+    if (!span) return;
+    var old = span.textContent;
+    span.textContent = msg;
+    setTimeout(function () { span.textContent = old; }, 1200);
+  }
+
+  // 找到最新的正式版（已排序，第一个非 prerelease）
+  function firstStableRelease() {
+    for (var i = 0; i < state.releases.length; i++) {
+      if (!state.releases[i].prerelease) return state.releases[i];
+    }
+    return null;
+  }
+
+  // ── 事件绑定 ─────────────────────────────────────────────────
+  function bindEvents() {
+    $all('.filter-btn').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var f = btn.getAttribute('data-filter');
+        if (!f || f === state.filter) return;
+        state.filter = f;
+        $all('.filter-btn').forEach(function (b) {
+          var active = b.getAttribute('data-filter') === f;
+          b.classList.toggle('active', active);
+          b.setAttribute('aria-selected', active ? 'true' : 'false');
+        });
+        if (state.releases.length) render();
+      });
+    });
+
+    $('#mirror-select').addEventListener('change', function (e) {
+      state.mirror = e.target.value;
+      try { localStorage.setItem('gh-release-mirror', state.mirror); } catch (err) {}
+      if (state.releases.length) render();
+    });
+
+    $('#refresh-btn').addEventListener('click', function () { load(); });
+    $('#retry-btn').addEventListener('click', function () { load(); });
+  }
+
+  // ── 启动 ─────────────────────────────────────────────────────
+  (function init() {
+    // 恢复镜像偏好
+    try {
+      var saved = localStorage.getItem('gh-release-mirror');
+      if (saved && MIRRORS[saved]) {
+        state.mirror = saved;
+        $('#mirror-select').value = saved;
+      }
+    } catch (e) {}
+
+    bindEvents();
+    load();
+  })();
+</script>
+
+</body>
+</html>

--- a/github-releases.html
+++ b/github-releases.html
@@ -300,9 +300,25 @@
 
 <main class="max-w-content mx-auto px-6 md:px-8 py-8 md:py-10">
 
+  <!-- 单 tag 模式横幅（通过 ?tag=xxx 进入时显示） -->
+  <div id="tag-banner" hidden class="mb-6 md:mb-8 bg-accent-light border border-accent/40 rounded-2xl px-5 py-4 flex flex-col md:flex-row md:items-center gap-3">
+    <div class="flex-1 min-w-0">
+      <div class="text-sm text-dark font-medium">
+        当前仅显示 tag：<code id="tag-banner-name" class="font-mono text-xs bg-white/70 border border-accent/30 px-1.5 py-0.5 rounded ml-1 break-all"></code>
+      </div>
+      <p class="mt-1 text-xs text-secondary">
+        页面已通过 <code class="font-mono bg-white/60 px-1 rounded">?tag=</code> 参数锁定到单个 release。如需浏览所有版本，请点击右侧按钮。
+      </p>
+    </div>
+    <a id="tag-banner-back" href="?" class="shrink-0 inline-flex items-center gap-1.5 border border-border bg-white hover:bg-gray-50 text-dark text-sm font-medium px-4 py-2 rounded-lg transition">
+      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg>
+      查看全部 releases
+    </a>
+  </div>
+
   <!-- 控制栏：筛选 + 镜像 + 刷新 -->
   <section class="mb-6 md:mb-8 flex flex-col gap-4">
-    <div class="flex flex-wrap items-center gap-3">
+    <div id="type-filter-row" class="flex flex-wrap items-center gap-3">
       <span class="text-sm text-secondary font-medium">版本类型：</span>
       <div class="flex flex-wrap gap-2" role="tablist" aria-label="版本类型筛选">
         <button type="button" class="filter-btn active border border-border bg-white text-dark text-sm font-medium px-4 py-1.5 rounded-full transition" data-filter="all" role="tab" aria-selected="true">全部</button>
@@ -376,6 +392,10 @@
           <p id="error-msg" class="text-sm text-secondary mb-4">无法从 GitHub API 获取版本信息。</p>
           <div class="flex flex-wrap gap-2">
             <button id="retry-btn" type="button" class="bg-accent hover:bg-accent-hover text-dark font-bold text-sm px-4 py-2 rounded-lg transition">重试</button>
+            <a id="error-back-to-all" hidden href="?" class="bg-dark hover:bg-black text-white font-bold text-sm px-4 py-2 rounded-lg transition inline-flex items-center gap-1.5">
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg>
+              查看全部 releases
+            </a>
             <a href="https://github.com/sudoprivacy/sudowork/releases" target="_blank" rel="noopener noreferrer" class="border border-border hover:bg-gray-50 text-dark font-medium text-sm px-4 py-2 rounded-lg transition">前往 GitHub</a>
           </div>
         </div>
@@ -419,6 +439,7 @@
   var OWNER = 'sudoprivacy';
   var REPO = 'sudowork';
   var API_URL = 'https://api.github.com/repos/' + OWNER + '/' + REPO + '/releases?per_page=100';
+  var API_TAG_URL = 'https://api.github.com/repos/' + OWNER + '/' + REPO + '/releases/tags/';
 
   // 国内可用的 GitHub 加速镜像
   // 每个函数接受原始 github.com 的下载 URL，返回加速后的 URL
@@ -450,8 +471,31 @@
     releases: [],        // 原始数据（已按 published_at DESC 排序）
     filter: 'all',       // all | release | prerelease
     mirror: 'ghfast',    // 选中镜像
-    fetchedAt: null
+    fetchedAt: null,
+    tag: null            // 若通过 ?tag=xxx 进入，则仅显示该 tag 对应的 release
   };
+
+  // 读取 URL 中的 ?tag= 参数（不存在则返回 null）
+  function getTagFromQuery() {
+    try {
+      var params = new URLSearchParams(window.location.search);
+      var t = params.get('tag');
+      if (!t) return null;
+      t = t.trim();
+      return t || null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  // 返回"查看全部 releases"的 href（当前路径，去除 query）
+  function allReleasesHref() {
+    try {
+      return window.location.pathname || 'github-releases.html';
+    } catch (e) {
+      return 'github-releases.html';
+    }
+  }
 
   // ── 工具函数 ─────────────────────────────────────────────────
   function $(sel) { return document.querySelector(sel); }
@@ -537,7 +581,13 @@
   // ── 数据加载 ─────────────────────────────────────────────────
   function load() {
     showLoading();
-    var url = API_URL + '&_t=' + Date.now(); // 破缓存
+    var url;
+    if (state.tag) {
+      // 按 tag 拉取单个 release。GitHub 对不存在的 tag 返回 404。
+      url = API_TAG_URL + encodeURIComponent(state.tag) + '?_t=' + Date.now();
+    } else {
+      url = API_URL + '&_t=' + Date.now(); // 破缓存
+    }
 
     fetch(url, {
       headers: { 'Accept': 'application/vnd.github+json' },
@@ -547,27 +597,41 @@
         if (!res.ok) {
           var hint = '';
           if (res.status === 403) hint = '（可能触发了 GitHub API 的速率限制，请稍后重试）';
-          if (res.status === 404) hint = '（仓库不存在或已私有）';
-          throw new Error('HTTP ' + res.status + ' ' + res.statusText + ' ' + hint);
+          else if (res.status === 404) {
+            hint = state.tag
+              ? '（未找到 tag "' + state.tag + '" 对应的 release，请确认 tag 是否存在且已发布）'
+              : '（仓库不存在或已私有）';
+          }
+          var err = new Error('HTTP ' + res.status + ' ' + res.statusText + ' ' + hint);
+          err.status = res.status;
+          throw err;
         }
         return res.json();
       })
       .then(function (data) {
-        if (!Array.isArray(data)) throw new Error('返回数据格式异常');
-
-        // 过滤 draft，按 published_at DESC 排序（prerelease 也按时间参与排序）
-        var list = data
-          .filter(function (r) { return !r.draft; })
-          .slice()
-          .sort(function (a, b) {
-            var ta = a.published_at ? new Date(a.published_at).getTime() : 0;
-            var tb = b.published_at ? new Date(b.published_at).getTime() : 0;
-            if (tb !== ta) return tb - ta;
-            // 次级排序：created_at
-            var ca = a.created_at ? new Date(a.created_at).getTime() : 0;
-            var cb = b.created_at ? new Date(b.created_at).getTime() : 0;
-            return cb - ca;
-          });
+        var list;
+        if (state.tag) {
+          // 单个 release 对象
+          if (!data || typeof data !== 'object' || Array.isArray(data)) {
+            throw new Error('返回数据格式异常');
+          }
+          list = data.draft ? [] : [data];
+        } else {
+          if (!Array.isArray(data)) throw new Error('返回数据格式异常');
+          // 过滤 draft，按 published_at DESC 排序（prerelease 也按时间参与排序）
+          list = data
+            .filter(function (r) { return !r.draft; })
+            .slice()
+            .sort(function (a, b) {
+              var ta = a.published_at ? new Date(a.published_at).getTime() : 0;
+              var tb = b.published_at ? new Date(b.published_at).getTime() : 0;
+              if (tb !== ta) return tb - ta;
+              // 次级排序：created_at
+              var ca = a.created_at ? new Date(a.created_at).getTime() : 0;
+              var cb = b.created_at ? new Date(b.created_at).getTime() : 0;
+              return cb - ca;
+            });
+        }
 
         state.releases = list;
         state.fetchedAt = new Date();
@@ -592,6 +656,16 @@
     $('#empty').hidden = true;
     $('#meta').hidden = true;
     $('#error-msg').textContent = msg || '未知错误';
+    // 在 tag 模式下显示"查看全部 releases"快捷按钮
+    var backBtn = $('#error-back-to-all');
+    if (backBtn) {
+      if (state.tag) {
+        backBtn.hidden = false;
+        backBtn.href = allReleasesHref();
+      } else {
+        backBtn.hidden = true;
+      }
+    }
   }
 
   // ── 渲染 ─────────────────────────────────────────────────────
@@ -625,12 +699,16 @@
     container.appendChild(frag);
 
     // meta
-    var total = state.releases.length;
-    var stable = state.releases.filter(function (r) { return !r.prerelease; }).length;
-    var pre = total - stable;
     $('#meta').hidden = false;
-    $('#meta-count').textContent =
-      '共 ' + total + ' 个版本（正式版 ' + stable + '，预发布 ' + pre + '）· 当前筛选：' + list.length + ' 个';
+    if (state.tag) {
+      $('#meta-count').textContent = '仅显示 tag: ' + state.tag;
+    } else {
+      var total = state.releases.length;
+      var stable = state.releases.filter(function (r) { return !r.prerelease; }).length;
+      var pre = total - stable;
+      $('#meta-count').textContent =
+        '共 ' + total + ' 个版本（正式版 ' + stable + '，预发布 ' + pre + '）· 当前筛选：' + list.length + ' 个';
+    }
     $('#meta-fetched').textContent = '拉取时间 ' + formatDate(state.fetchedAt.toISOString());
   }
 
@@ -646,7 +724,8 @@
     var title = r.name && r.name.trim() ? r.name.trim() : r.tag_name || '(未命名)';
     var tag = r.tag_name || '';
     var isPre = !!r.prerelease;
-    var isLatest = !isPre && r === firstStableRelease();
+    // tag 模式下只取到单个 release，不能判断它是否真的是最新稳定版，因此不标记 Latest
+    var isLatest = !state.tag && !isPre && r === firstStableRelease();
 
     var badges = '';
     if (isPre) {
@@ -877,6 +956,31 @@
     $('#retry-btn').addEventListener('click', function () { load(); });
   }
 
+  // 应用 tag 模式下的 UI 调整
+  function applyTagModeUI() {
+    var banner = $('#tag-banner');
+    var typeRow = $('#type-filter-row');
+    if (state.tag) {
+      // 显示横幅
+      if (banner) {
+        banner.hidden = false;
+        var nameEl = $('#tag-banner-name');
+        if (nameEl) nameEl.textContent = state.tag;
+        var backEl = $('#tag-banner-back');
+        if (backEl) backEl.href = allReleasesHref();
+      }
+      // 隐藏正式版/预发布 Tab（按 tag 过滤时没有意义）
+      if (typeRow) typeRow.hidden = true;
+      // 标题里强调 tag
+      try {
+        document.title = 'SudoWork Release · ' + state.tag + ' — 版本下载';
+      } catch (e) {}
+    } else {
+      if (banner) banner.hidden = true;
+      if (typeRow) typeRow.hidden = false;
+    }
+  }
+
   // ── 启动 ─────────────────────────────────────────────────────
   (function init() {
     // 恢复镜像偏好
@@ -887,6 +991,10 @@
         $('#mirror-select').value = saved;
       }
     } catch (e) {}
+
+    // 解析 ?tag=xxx
+    state.tag = getTagFromQuery();
+    applyTagModeUI();
 
     bindEvents();
     load();

--- a/github-releases.html
+++ b/github-releases.html
@@ -254,6 +254,9 @@
       background: #fafbfc;
     }
 
+    /* 让 HTML `hidden` 属性胜过 Tailwind 的 display 工具类（如 flex / inline-flex） */
+    [hidden] { display: none !important; }
+
     @media (prefers-reduced-motion: reduce) {
       html { scroll-behavior: auto; }
       .skeleton, .spinner { animation: none; }


### PR DESCRIPTION
## Summary
- 新增独立页面 `github-release.html`：通过 GitHub API 实时获取 `sudoprivacy/sudowork` 的 releases，按 `published_at` 倒序排列，区分正式版与预发布。
- 为每个 asset 提供国内可用的加速镜像（ghfast.top / gh-proxy.com / mirror.ghproxy.com / github.moeyy.xyz），并支持全局切换（偏好持久化）。
- 刻意保持独立：`noindex,nofollow`，未在任何现有页面添加指向本页的链接。

## Test plan
- [ ] 部署后访问 `/github-release.html`确认加载正常
- [ ] 切换各镜像验证国内下载可用
- [ ] 检查正式版 / 预发布 tab 筛选
- [ ] 确认其他页面无任何入口指向此页

🤖 Generated with [Claude Code](https://claude.ai/code)
Resolves #50