### PR TITLE
fix: update download domain from sudowork to sudoclaw

### DIFF
--- a/index.html
+++ b/index.html
@@ -2191,7 +2191,7 @@
           <p class="text-sm font-medium text-dark mb-2">.dmg（Apple 芯片）</p>
           <a
             id="download-macos-arm"
-            href="https://sudowork-download-1309794936.cos.ap-beijing.myqcloud.com/sudowork/release/latest/Sudowork-latest-mac-arm64.dmg"
+            href="https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/sudowork/release/latest/Sudowork-latest-mac-arm64.dmg"
             class="flex w-full items-center gap-2 rounded-lg bg-accent px-4 py-3 text-sm font-bold font-heading text-dark shadow-sm transition-colors duration-200 hover:bg-accent-hover"
             aria-label="下载 macOS Apple 芯片版"
             rel="noopener noreferrer"
@@ -2227,7 +2227,7 @@
           <p class="text-sm font-medium text-dark mb-2">Windows x64</p>
           <a
             id="download-windows-x64"
-            href="https://sudowork-download-1309794936.cos.ap-beijing.myqcloud.com/sudowork/release/latest/Sudowork-latest-win-x64.exe"
+            href="https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/sudowork/release/latest/Sudowork-latest-win-x64.exe"
             class="flex w-full items-center gap-2 rounded-lg bg-accent px-4 py-3 text-sm font-bold font-heading text-dark shadow-sm transition-colors duration-200 hover:bg-accent-hover"
             aria-label="下载 Windows x64 版"
             rel="noopener noreferrer"


### PR DESCRIPTION
## Summary
- Update download CDN domain from `sudowork-download` to `sudoclaw-download`
- Affects macOS ARM64 and Windows x64 download links

## Test plan
- [ ] Verify download links work correctly with new domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)